### PR TITLE
Proper way to check Object type membership

### DIFF
--- a/polyfill.js
+++ b/polyfill.js
@@ -9,7 +9,7 @@ if (!('fromEntries' in Object)) {
     const obj = {};
 
     for (const [ index, pair ] of pairs.entries()) {
-      if (!pair || typeof pair !== 'object') {
+      if (Object(pair) !== pair) {
         // Consistent messaging to Chrome when initializing a Map:
         throw new TypeError(`Iterator value ${ index } is not an entry object`);
       }


### PR DESCRIPTION
`typeof value === "object"` is an unreliable way to check if `value` is an object, because it gives false positives for null, false negatives for callable objects, and it's implementation-dependent for non-callable non-standard exotic objects.