### PR TITLE
Use [[DefineOwnProperty]] instead of [[Set]] in polyfill

### DIFF
--- a/polyfill.js
+++ b/polyfill.js
@@ -26,7 +26,12 @@ if (!('fromEntries' in Object)) {
         throw new TypeError(`Entry object key must be a string`);
       }
 
-      obj[key] = val;
+      Object.defineProperty(obj, key, {
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value: val,
+      });
     }
 
     return obj;


### PR DESCRIPTION
In #2 it was decided to do this change to the algorithm, but the polyfill was not updated. This affects the result of `Object.fromEntries([["__proto__", {}]])`