### PR TITLE
Removes string-key requirement; uses ToPropertyKey to coerce keys. Addresses #5.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,11 @@ steps are taken:
         <a href="https://tc39.github.io/ecma262/#sec-iteratorclose">IteratorClose</a>(<i>iter</i>, <i>key</i>).
       </li>
       <li>
-        Let <i>propertyKey</i> be ?
+        Let <i>propertyKey</i> be
         <a href="http://www.ecma-international.org/ecma-262/8.0/#sec-topropertykey">ToPropertyKey</a>(<i>key</i>).
+      </li>
+      <li>
+        If <i>propertyKey</i> is an abrupt completion, return ? <a href="https://tc39.github.io/ecma262/#sec-iteratorclose">IteratorClose</a>(<i>iter</i>, <i>propertyKey</i>).
       </li>
       <li>Let <i>value</i> be <a href="https://tc39.github.io/ecma262/#sec-get-o-p">Get</a>(<i>nextItem</i>, "1").</li>
       <li>

--- a/README.md
+++ b/README.md
@@ -206,15 +206,15 @@ have symbol keys while the former never would.
 
   <p>Original text:</p>
 
-  <p>
-    <del>
+  <blockquote>
+    <p>
       It would be valuable if given an iterable `entries` that
       `Object.entries(Object.fromEntries(entries))` would always return an array
       whose membership (at the key/value level) is identical to `entries`. To
       achieve this behavior, however, we must disallow symbols as keys, because
       `Object.entries` filters out symbol-keyed properties.
-    </del>
-  </p>
+    </p>
+  </blockquote>
 </details>
 
 ### Coercion of keys
@@ -230,25 +230,22 @@ access or defineOwnProperty, etc.
 
   <p>Original text:</p>
 
-  <p>
-    <del>
+  <blockquote>
+    <p>
       In the proposed behavior above, no coercion of _k_ to a valid property key
       occurs — it must be a string. I believe this is likely the best behavior
       for the use cases envisioned, but possibly users would expect it to behave
       instead like computed assignment, which will attempt coercing any value to
       a property key.
-    </del>
-  </p>
-
-  <p>
-    <del>
+    </p>
+    <p>
       Assuming no coercion, and regardless of the restriction on symbol keys,
       one could argue that invalid keys, or perhaps symbol keys specifically,
       should be ignored rather than cause an exception to be thrown. I don’t
       think this is likely the desired behavior, but I figured I should note the
       possibility.
-    </del>
-  </p>
+    </p>
+  </blockquote>
 </details>
 
 ### Additional arguments

--- a/polyfill.js
+++ b/polyfill.js
@@ -4,23 +4,15 @@ if (!('fromEntries' in Object)) {
 
     const obj = {};
 
-    for (const [ index, pair ] of pairs.entries()) {
+    for (const pair of iter) {
       if (Object(pair) !== pair) {
-        // Consistent messaging to Chrome when initializing a Map:
-        throw new TypeError(`Iterator value ${ index } is not an entry object`);
+        throw new TypeError(`iterable for fromEntries should yield objects`);
       }
 
-      // Consistency with Map: object need not be technically iterable:
+      // Consistency with Map: contract is that entry has "0" and "1" keys, not
+      // that it is an array or iterable.
 
       const { 0: key, 1: val } = pair;
-
-      // Such that Object.entries(Object.fromEntries(obj)) always yield the
-      // "same" list of entries, symbols are prohibited (along with any other
-      // non-string keys):
-
-      if (typeof key !== 'string') {
-        throw new TypeError(`Entry object key must be a string`);
-      }
 
       Object.defineProperty(obj, key, {
         configurable: true,


### PR DESCRIPTION
Follow up on changes discussed in #5 and also addresses comments about polyfill implementation in PR #8.

@ljharb, @zloirock